### PR TITLE
fix: send the start message multiple times after /reset

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -89,14 +89,17 @@ def handle(message_id, open_id, uuid, text):
     msg = ""
     resp_message_id = reply_message(message_id, msg, card=True)
     last_time = time.time()
+    first_init = True
     for data in chatbot.ask(text, conversation_id=conversation_id, parent_id=parent_id):
         # automatically rename for new chat
         if conversation_id is None:
-            name = get_user_name(open_id)
-            title = conf.get("title", uuid)
-            title = f"{name} - {title}"
-            chatbot.change_title(data["conversation_id"], title)
-            reply_message(message_id, f"开始新对话：{title}")
+            if first_init:
+                name = get_user_name(open_id)
+                title = conf.get("title", uuid)
+                title = f"{name} - {title}"
+                chatbot.change_title(data["conversation_id"], title)
+                reply_message(message_id, f"开始新对话：{title}")
+                first_init = False
 
         msg = data["message"]
         if time.time() - last_time > 0.3:


### PR DESCRIPTION
修复个bug，发送 /reset 后，再发送消息，会发送很多次 开始新对话
![image](https://user-images.githubusercontent.com/55790198/221484702-47eb8c3d-b245-42b2-a91d-b5fa7c362327.png)
